### PR TITLE
Fix Mac OS build

### DIFF
--- a/.github/actions/php/darwin/configure/action.yml
+++ b/.github/actions/php/darwin/configure/action.yml
@@ -28,7 +28,9 @@ runs:
           --with-config-file-path=/etc \
           --with-config-file-scan-dir=/etc/php.d \
           --with-iconv=/usr/local/opt/libiconv \
-          --enable-embed \
+          --enable-embed=static \
+          --enable-static \
+          --enable-shared=no \
           --enable-zts \
           --disable-zend-signals \
           --enable-debug \


### PR DESCRIPTION
`--embed=static` was missing in #1.

We'll probably also need `--disable-opcache-jit` too: https://github.com/dunglas/frankenphp/blob/main/docs/compile.md#mac